### PR TITLE
fix: 修复连接直播间时重复添加 handler 导致重复输出的错误

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 1. 使用 `git clone git@github.com:Nemo2011/bilibili_api.git` 将本仓库拉取到本地。
 2. 使用 `cd bilibili-api` 切换到仓库位置。
-3. 使用 `python -r requirements.txt` 安装相关依赖。
+3. 使用 `pip install -r requirements.txt` 安装相关依赖。
 4. **使用 `python install.py` 进行初始化**，该项非常重要，将会初始化 Git Hooks。
 5. 使用 `git checkout dev && git checkout -b {分支名}` 从 dev 分支切换到一个新的分支再进行编码。
 6. 开发完毕后，使用 `git push -u origin {分支名}` 将分支推送到你 fork 的仓库。

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -691,13 +691,14 @@ class LiveDanmaku(AsyncEvent):
         # logging
         self.logger = logging.getLogger(f"LiveDanmaku_{self.room_display_id}")
         self.logger.setLevel(logging.DEBUG if debug else logging.INFO)
-        handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter(
-                "[" + str(room_display_id) + "][%(asctime)s][%(levelname)s] %(message)s"
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter(
+                    "[" + str(room_display_id) + "][%(asctime)s][%(levelname)s] %(message)s"
+                )
             )
-        )
-        self.logger.addHandler(handler)
+            self.logger.addHandler(handler)
 
     def get_status(self):
         """


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# 修复连接直播间时重复添加 handler 导致重复输出的错误
- 1. live.LiveDanmaku.logger
- 2. 一点文档笔误？

### LiveDanmaku 多次连接同一直播间时，由于获取其 logger 时的名字不变，导致 handlers 重复添加，加入判断可解决。重复输出截图如下：
![](https://user-images.githubusercontent.com/41439182/178446241-9017b7df-a592-4564-a226-54546cfc1ae6.png)
